### PR TITLE
Add support for injecting of definition storage to ezcWorkflowDatabaseExecution

### DIFF
--- a/WorkflowDatabaseTiein/src/execution.php
+++ b/WorkflowDatabaseTiein/src/execution.php
@@ -67,7 +67,7 @@ class ezcWorkflowDatabaseExecution extends ezcWorkflowExecution
      * @param  int          $executionId
      * @throws ezcWorkflowExecutionException
      */
-    public function __construct ( ezcDbHandler $db, $executionId = null )
+    public function __construct ( ezcDbHandler $db, $executionId = null, ezcWorkflowDefinitionStorage $definitionStorage = null )
     {
         if ( $executionId !== null && !is_int( $executionId ) )
         {
@@ -75,7 +75,14 @@ class ezcWorkflowDatabaseExecution extends ezcWorkflowExecution
         }
 
         $this->db = $db;
-        $this->properties['definitionStorage'] = new ezcWorkflowDatabaseDefinitionStorage( $db );
+
+        $this->properties['definitionStorage'] = $definitionStorage;
+
+        if ( $this->properties['definitionStorage'] === null )
+        {
+            $this->properties['definitionStorage'] = new ezcWorkflowDatabaseDefinitionStorage( $db );
+        }
+
         $this->properties['options'] = new ezcWorkflowDatabaseOptions;
 
         if ( is_int( $executionId ) )


### PR DESCRIPTION
When we need support for prefixed tables, in current implementation it is not possible
to specify options which should be passed to the constructor of ezcWorkflowDatabaseDefinitionStorage
instantiated by default in constructor of ezcWorkflowDatabaseExecution. If definition storage
is runtime requirement of the class ezcWorkflowDatabaseExecution, it should be possible
to inject our own implementation.
