### PR TITLE
Last single character chunk not read

### DIFF
--- a/Search/src/handlers/solr.php
+++ b/Search/src/handlers/solr.php
@@ -236,7 +236,7 @@ class ezcSearchSolrHandler implements ezcSearchHandler, ezcSearchIndexHandler
                 $chunkLength = hexdec( $line );
 
                 $size = 1;
-                while ( $size < $chunkLength )
+                while ( $size <= $chunkLength )
                 {
                     $line = $this->getLine( $chunkLength );
                     $size += strlen( $line );


### PR DESCRIPTION
When solr returns a 2x 8192 + 1 length response in chunk transfer mode the last chunk is not being added to the result. Therefor the json string cannot be decoded properly.
