### PR TITLE
Trim "\0" from the entry path

### DIFF
--- a/Archive/src/entry.php
+++ b/Archive/src/entry.php
@@ -212,11 +212,11 @@ class ezcArchiveEntry
     {
         if ( $withPrefix )
         {
-            return $this->fileStructure->path;
+            return trim($this->fileStructure->path);
         }
         else
         {
-            return $this->getPathWithoutPrefix( $this->fileStructure->path, $this->prefix );
+            return $this->getPathWithoutPrefix( trim($this->fileStructure->path), $this->prefix );
         }
     }
 


### PR DESCRIPTION
Sometimes, in an archive, the entry path was designed to be fix-width string (e.g, 256 chars) and "\0" will be used as the invisible place-holder. 

If we don't trim the "\0" placeholders, the archive entries will not be extracted successfully.
